### PR TITLE
implemented code for http_file flags

### DIFF
--- a/examples/http_upload/main.go
+++ b/examples/http_upload/main.go
@@ -1,0 +1,74 @@
+// Refer to the Shaka Packager HTTP upload tutorial for more details:
+// https://shaka-project.github.io/shaka-packager/html/tutorials/http_upload.html
+// This implementation follows the HTTP upload process, ensuring media segments
+// and MPD files are uploaded correctly to the specified server.
+package main
+
+import (
+	"fmt"
+	"log"
+	"path"
+
+	packlit "github.com/m4urici0gm/packlit/pkg"
+)
+
+func buildFlags(uploadURL string) *packlit.ShakaFlags {
+	return packlit.NewFlags(
+		packlit.WithUserAgentFlag("Packlit-client/1.0"),
+		packlit.WithCaFileFlag("/etc/ssl/certs/ca-certificates.crt"),
+		packlit.WithClientCertFileFlag("/etc/ssl/certs/client-cert.pem"),
+		packlit.WithClientCertPrivateKeyFileFlag("/etc/ssl/private/client-key.pem"),
+		packlit.WithClientCertPrivateKeyPasswordFlag("supersecurepassword"),
+		packlit.WithDisablePeerVerificationFlag(),
+		packlit.WithIgnoreHttpOutputFailuresFlag(),
+		packlit.WithStaticLiveMpd(),
+		packlit.WithSegmentDuration("4"),
+		packlit.WithMpdOutput(path.Join(uploadURL, "h264.mpd")),
+	)
+}
+
+type stream struct {
+	streamType packlit.StreamType
+	input      string
+}
+
+func main() {
+	uploadURL := "http://localhost:6767/vod"
+
+	streams := []stream{
+		{streamType: "audio", input: "audio.mp4"},
+		{streamType: "video", input: "video.mp4"},
+	}
+
+	builder := packlit.NewBuilder()
+	flags := buildFlags(uploadURL)
+
+	for _, stream := range streams {
+		initSegment := path.Join(uploadURL, fmt.Sprintf("%v-init.mp4", stream.streamType))
+		segmentTemplate := path.Join(uploadURL, fmt.Sprintf("%v-$Time$.m4s", stream.streamType))
+
+		builder.WithStream(
+			packlit.NewStreamBuilder().
+				WithInput(stream.input).
+				WithStream(stream.streamType).
+				AddOption(packlit.WithInitSegment(initSegment)).
+				AddOption(packlit.WithSegmentTemplate(segmentTemplate)).
+				Build(),
+		)
+	}
+
+	packager := builder.WithFlag(flags).Build()
+
+	cmd, err := packager.PreviewCommand()
+	if err != nil {
+		log.Fatalf("error: when previewing command %v", err)
+	}
+
+	// Print command
+	log.Println(cmd)
+
+	packagerExecutor := packlit.NewExecutor(packager)
+	if err := packagerExecutor.Run(); err != nil {
+		log.Fatalf("error when running shaka-packager: %v", err)
+	}
+}

--- a/pkg/flags.go
+++ b/pkg/flags.go
@@ -15,6 +15,14 @@ var (
 	_             = (*GenerateStaticLiveMpd)(nil)
 	_             = (*DumpStreamInfo)(nil)
 	_             = (*BaseUrls)(nil)
+	_             = (*UserAgentFlag)(nil)
+	_             = (*CaFileFlag)(nil)
+	_             = (*ClientCertFileFlag)(nil)
+	_             = (*ClientCertPrivateKeyFileFlag)(nil)
+	_             = (*ClientCertPrivateKeyPasswordFlag)(nil)
+	_             = (*DisablePeerVerificationFlag)(nil)
+	_             = (*IgnoreHttpOutputFailuresFlag)(nil)
+	_             = (*IoCacheSizeFlag)(nil)
 )
 
 func buildFlags(flags *ShakaFlags) ([]string, error) {
@@ -85,9 +93,9 @@ func (g DumpStreamInfo) Validate() error {
 type BaseUrls []string
 
 func (b BaseUrls) Parse() string {
-    return fmt.Sprintf("--base_urls=%s", strings.Join(b, ","))
+	return fmt.Sprintf("--base_urls=%s", strings.Join(b, ","))
 }
 
 func (b BaseUrls) Validate() error {
-    return nil
+	return nil
 }

--- a/pkg/http_file_flags.go
+++ b/pkg/http_file_flags.go
@@ -1,0 +1,91 @@
+package packlit
+
+import "fmt"
+
+// UserAgentFlag represents the flag for setting a custom User-Agent string for HTTP requests.
+type UserAgentFlag string
+
+func (u UserAgentFlag) Parse() string {
+	return fmt.Sprintf("--user_agent=%s", u)
+}
+
+func (u UserAgentFlag) Validate() error {
+	return nil
+}
+
+// CaFileFlag represents the flag for setting the Certificate Authority file for the server cert.
+type CaFileFlag string
+
+func (c CaFileFlag) Parse() string {
+	return fmt.Sprintf("--ca_file=%s", c)
+}
+
+func (c CaFileFlag) Validate() error {
+	return nil
+}
+
+// ClientCertFileFlag represents the flag for setting the client certificate file path.
+type ClientCertFileFlag string
+
+func (c ClientCertFileFlag) Parse() string {
+	return fmt.Sprintf("--client_cert_file=%s", c)
+}
+
+func (c ClientCertFileFlag) Validate() error {
+	return nil
+}
+
+// ClientCertPrivateKeyFileFlag represents the flag for setting the Private Key file path for the client cert.
+type ClientCertPrivateKeyFileFlag string
+
+func (c ClientCertPrivateKeyFileFlag) Parse() string {
+	return fmt.Sprintf("--client_cert_private_key_file=%s", c)
+}
+
+func (c ClientCertPrivateKeyFileFlag) Validate() error {
+	return nil
+}
+
+// ClientCertPrivateKeyPasswordFlag represents the flag for setting the password to the private key file.
+type ClientCertPrivateKeyPasswordFlag string
+
+func (c ClientCertPrivateKeyPasswordFlag) Parse() string {
+	return fmt.Sprintf("--client_cert_private_key_password=%s", c)
+}
+
+func (c ClientCertPrivateKeyPasswordFlag) Validate() error {
+	return nil
+}
+
+// DisablePeerVerificationFlag represents the flag for disabling peer verification for HTTP connections.
+type DisablePeerVerificationFlag struct{}
+
+func (d DisablePeerVerificationFlag) Parse() string {
+	return "--disable_peer_verification"
+}
+
+func (d DisablePeerVerificationFlag) Validate() error {
+	return nil
+}
+
+// IgnoreHttpOutputFailuresFlag represents the flag for ignoring HTTP output failures.
+type IgnoreHttpOutputFailuresFlag struct{}
+
+func (i IgnoreHttpOutputFailuresFlag) Parse() string {
+	return "--ignore_http_output_failures"
+}
+
+func (i IgnoreHttpOutputFailuresFlag) Validate() error {
+	return nil
+}
+
+// IoCacheSizeFlag represents the flag for setting the IO cache size.
+type IoCacheSizeFlag uint
+
+func (i IoCacheSizeFlag) Parse() string {
+	return fmt.Sprintf("--io_cache_size=%d", i)
+}
+
+func (i IoCacheSizeFlag) Validate() error {
+	return nil
+}

--- a/pkg/http_file_flags_helpers.go
+++ b/pkg/http_file_flags_helpers.go
@@ -1,0 +1,57 @@
+package packlit
+
+// WithUserAgentFlag Adds flag '--user_agent <value>'
+func WithUserAgentFlag(val string) ShakaFlagFn {
+	return func(so *ShakaFlags) {
+		so.Add(UserAgentFlag(val))
+	}
+}
+
+// WithCaFileFlag Adds flag '--ca_file <value>'
+func WithCaFileFlag(val string) ShakaFlagFn {
+	return func(so *ShakaFlags) {
+		so.Add(CaFileFlag(val))
+	}
+}
+
+// WithClientCertFileFlag Adds flag '--client_cert_file <value>'
+func WithClientCertFileFlag(val string) ShakaFlagFn {
+	return func(so *ShakaFlags) {
+		so.Add(ClientCertFileFlag(val))
+	}
+}
+
+// WithClientCertPrivateKeyFileFlag Adds flag '--client_cert_private_key_file <value>'
+func WithClientCertPrivateKeyFileFlag(val string) ShakaFlagFn {
+	return func(so *ShakaFlags) {
+		so.Add(ClientCertPrivateKeyFileFlag(val))
+	}
+}
+
+// WithClientCertPrivateKeyPasswordFlag Adds flag '--client_cert_private_key_password <value>'
+func WithClientCertPrivateKeyPasswordFlag(val string) ShakaFlagFn {
+	return func(so *ShakaFlags) {
+		so.Add(ClientCertPrivateKeyPasswordFlag(val))
+	}
+}
+
+// WithDisablePeerVerificationFlag Adds flag '--disable_peer_verification'
+func WithDisablePeerVerificationFlag() ShakaFlagFn {
+	return func(so *ShakaFlags) {
+		so.Add(DisablePeerVerificationFlag{})
+	}
+}
+
+// WithIgnoreHttpOutputFailuresFlag Adds flag '--ignore_http_output_failures'
+func WithIgnoreHttpOutputFailuresFlag() ShakaFlagFn {
+	return func(so *ShakaFlags) {
+		so.Add(IgnoreHttpOutputFailuresFlag{})
+	}
+}
+
+// WithIoCacheSizeFlag Adds flag '--io_cache_size <value>'
+func WithIoCacheSizeFlag(val uint) ShakaFlagFn {
+	return func(so *ShakaFlags) {
+		so.Add(IoCacheSizeFlag(val))
+	}
+}


### PR DESCRIPTION
I implemented HTTP upload file flags by adding the necessary flags and helper functions, all sourced from Shaka Packager's [[hls_flags.cc](https://github.com/shaka-project/shaka-packager/blob/c819deaa2376399a89d41f3804bc72f4a20d9d6d/packager/app/hls_flags.cc)](https://github.com/shaka-project/shaka-packager/blob/c819deaa2376399a89d41f3804bc72f4a20d9d6d/packager/app/hls_flags.cc). This enables HTTP file uploads using well-established configurations from Shaka Packager. For more details on HTTP upload support, refer to the [[Shaka Packager HTTP Upload tutorial](https://shaka-project.github.io/shaka-packager/html/tutorials/http_upload.html)](https://shaka-project.github.io/shaka-packager/html/tutorials/http_upload.html).